### PR TITLE
Configuring CSS class to use random japanese font when not hovering

### DIFF
--- a/Jitai.user.js
+++ b/Jitai.user.js
@@ -360,7 +360,7 @@
         //  - normal  : randomized font
         //  - hovering: default font
         let style = document.createElement("style");
-        style.appendChild(document.createTextNode(".character-header__characters:hover { font-family: var(--font-family-japanese-hover); }"));
+        style.appendChild(document.createTextNode(".character-header__characters { font-family: var(--font-family-japanese); } .character-header__characters:hover { font-family: var(--font-family-japanese-hover); }"));
         item_element.style.setProperty("--font-family-japanese-hover", font_default);
         document.head.appendChild(style);
         


### PR DESCRIPTION
Jitai stopped working, after taking a look the cause was that the behaviour when not hovering was not set and that caused the random font to not be used.