### PR TITLE
Include the required wkof.Menu module

### DIFF
--- a/Jitai.user.js
+++ b/Jitai.user.js
@@ -770,7 +770,7 @@ p.font_legend {
             return;
         }
 
-        const wkof_modules = 'Settings';
+        const wkof_modules = 'Settings, Menu';
         wkof.include(wkof_modules);
         return wkof
             .ready(wkof_modules)


### PR DESCRIPTION
Jitai 3.3.5 failed to load for me: WaniKani is as if Jitai was not installed at all, and the browser console has an error:

```
Uncaught (in promise) TypeError: Unhandled Promise Rejection: wkof.Menu is undefined
```

This change fixes it for me. It was a guess based on `Menu` only being mentioned in `supported_modules` in wkof’s code, and https://community.wanikani.com/t/wanikani-open-framework-developer-thread/22231/2 showing `wkof.include(…)`